### PR TITLE
feat: CS-3158 - Enhance the logging of Data Deletion Job (#100)

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -88,10 +88,12 @@ public class ExpiryCheckService
 
                 var credentials = outerLoopRepositories.GetInstance<ICompanySsiDetailsRepository>()
                     .GetExpiryData(now, inactiveVcsToDelete, expiredVcsToDelete);
+                _logger.LogInformation("Total number of credentials to be processed for details are {Count}", await credentials.CountAsync(stoppingToken).ConfigureAwait(false));
                 await foreach (var credential in credentials.WithCancellation(stoppingToken).ConfigureAwait(false))
                 {
                     await ProcessCredentials(credential, companySsiDetailsRepository, repositories, portalService, processStepRepository, stoppingToken).ConfigureAwait(ConfigureAwaitOptions.None);
                 }
+                _logger.LogInformation("Credential details process completed successfully");
             }
             catch (Exception ex)
             {
@@ -109,21 +111,30 @@ public class ExpiryCheckService
         IProcessStepRepository<ProcessTypeId, ProcessStepTypeId> processStepRepository,
         CancellationToken cancellationToken)
     {
-        if (data.ScheduleData.IsVcToDelete)
+        try
         {
-            companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
-        }
-        else if (data.ScheduleData.IsVcToDecline)
-        {
-            HandleDecline(data.Id, companySsiDetailsRepository, processStepRepository);
-        }
-        else
-        {
-            await HandleNotification(data, companySsiDetailsRepository, portalService, cancellationToken).ConfigureAwait(false);
-        }
+            if (data.ScheduleData.IsVcToDelete)
+            {
+                companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
+            }
+            else if (data.ScheduleData.IsVcToDecline)
+            {
+                HandleDecline(data.Id, companySsiDetailsRepository, processStepRepository);
+            }
+            else
+            {
+                await HandleNotification(data, companySsiDetailsRepository, portalService, cancellationToken).ConfigureAwait(false);
+            }
 
-        // Saving here to make sure the each credential is handled by there own 
-        await repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+            // Saving here to make sure the each credential is handled by there own 
+            await repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+
+        }
+        catch (Exception ex)
+        {
+            var message = $"An error occurred while processing credential details '{ex.Message}' for ID '{data.Id}'";
+            throw new InvalidOperationException(message, ex);
+        }
     }
 
     private static void HandleDecline(

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -132,7 +132,7 @@ public class ExpiryCheckService
         }
         catch (Exception ex)
         {
-            var message = $"An error occurred while processing credential details '{ex.Message}' for ID '{data.Id}'";
+            var message = $"Failed to process credential with ID '{data.Id}': {ex.Message}";
             throw new InvalidOperationException(message, ex);
         }
     }

--- a/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
+++ b/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
@@ -211,40 +211,35 @@ public class ExpiryCheckServiceTests
     [Fact]
     public async Task ExecuteAsync_ThrowsException()
     {
+        // Arrange
         var now = DateTimeOffset.UtcNow;
-        var inactiveVcsToDelete = now.AddDays(-_settings.InactiveVcsToDeleteInDays);
         var credentialId = Guid.NewGuid();
         var credentialScheduleData = _fixture.Build<CredentialScheduleData>()
             .With(x => x.IsVcToDelete, true)
             .Create();
         var credentialsData = new CredentialExpiryData[]
         {
-            new(Guid.NewGuid(), "INVALID_REQUESTER_ID", null, null, null, Bpnl , CompanySsiDetailStatusId.INACTIVE, VerifiedCredentialTypeId.MEMBERSHIP, VerifiedCredentialExternalTypeId.MEMBERSHIP_CREDENTIAL, credentialScheduleData)
+            new(credentialId, "INVALID_REQUESTER_ID", null, null, null, Bpnl, CompanySsiDetailStatusId.INACTIVE, VerifiedCredentialTypeId.MEMBERSHIP, VerifiedCredentialExternalTypeId.MEMBERSHIP_CREDENTIAL, credentialScheduleData)
         };
+
+        // Mock logger, serviceProvider, and serviceScope
+        var logger = A.Fake<ILogger<ExpiryCheckService>>();
+        var serviceProvider = A.Fake<IServiceProvider>();
+        A.CallTo(() => serviceProvider.GetRequiredService<IIssuerRepositories>()).Returns(_issuerRepositories);
+        A.CallTo(() => serviceProvider.GetRequiredService<IDateTimeProvider>()).Returns(_dateTimeProvider);
+        A.CallTo(() => serviceProvider.GetRequiredService<IPortalService>()).Returns(_portalService);
+        var serviceScope = A.Fake<IServiceScope>();
+        A.CallTo(() => serviceScope.ServiceProvider).Returns(serviceProvider);
+        var serviceScopeFactory = A.Fake<IServiceScopeFactory>();
+        A.CallTo(() => serviceScopeFactory.CreateScope()).Returns(serviceScope);
 
         A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
         A.CallTo(() => _companySsiDetailsRepository.GetExpiryData(A<DateTimeOffset>._, A<DateTimeOffset>._, A<DateTimeOffset>._))
             .Returns(credentialsData.ToAsyncEnumerable());
 
         // Mock RemoveSsiDetail to throw an exception
-        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(A<Guid>._, A<string>._, A<string>._))
-            .Throws(new Exception("An error occurred while processing the credentials"));
-
-        A.CallTo(() => _issuerRepositories.GetInstance<IProcessStepRepository>())
-            .Returns(_processStepRepository);
-        A.CallTo(() => _issuerRepositories.GetInstance<ICompanySsiDetailsRepository>())
-            .Returns(_companySsiDetailsRepository);
-
-        //Mock logger, serviceProvider, and serviceScope
-        var logger = A.Fake<ILogger<ExpiryCheckService>>();
-        var serviceProvider = _fixture.Create<IServiceProvider>();
-        A.CallTo(() => serviceProvider.GetService(typeof(IIssuerRepositories))).Returns(_issuerRepositories);
-        A.CallTo(() => serviceProvider.GetService(typeof(IDateTimeProvider))).Returns(_dateTimeProvider);
-        A.CallTo(() => serviceProvider.GetService(typeof(IPortalService))).Returns(_portalService);
-        var serviceScope = _fixture.Create<IServiceScope>();
-        A.CallTo(() => serviceScope.ServiceProvider).Returns(serviceProvider);
-        var serviceScopeFactory = _fixture.Create<IServiceScopeFactory>();
-        A.CallTo(() => serviceScopeFactory.CreateScope()).Returns(serviceScope);
+        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(credentialId, A<string>._, A<string>._))
+            .Throws(new Exception("Test exception"));
 
         var sut = new ExpiryCheckService(serviceScopeFactory, logger, Options.Create(_settings));
 
@@ -252,12 +247,10 @@ public class ExpiryCheckServiceTests
         await sut.ExecuteAsync(CancellationToken.None);
 
         // Assert
-        var credentialsId = credentialsData.FirstOrDefault()?.Id;
         A.CallTo(logger).Where(call => call.Method.Name == "Log")
             .WhenArgumentsMatch(args =>
                 args[0]!.Equals(LogLevel.Error) &&
-                args[3] is Exception ex &&
-                ex.Message.Contains($"An error occurred while processing credential details 'An error occurred while processing the credentials' for ID '{credentialsId}'")
+                args[2]!.ToString()!.Contains("Verified Credential expiry check failed with error: Test exception")
             )
             .MustHaveHappened();
     }


### PR DESCRIPTION
Note: This is a cherry-pick from the private repository of the project

Ref: https://github.com/Cofinity-X/ssi-credential-issuer/pull/100

## Description

The Data Deletion Job is responsible for delete and notify the portal credentials that are about to expire. With the current log file it is not possible to identify if the service deleted or notified the Portal regarding any credential. It is possible to know only that the Job has run well.

-  logs added

## Why

- To enhance the logging capabilities in order to monitor

## Issue

https://cofinity-x.atlassian.net/browse/CS-3159

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
